### PR TITLE
Increase timer size

### DIFF
--- a/assets/test_workouts.json
+++ b/assets/test_workouts.json
@@ -13,6 +13,27 @@
         "config": { "sets": 1, "duration": 3 }
       },
       {
+        "drillId": "med_timed_drill",
+        "name": "Test: Timed Drill",
+        "description": "A 20-second timed drill.",
+        "type": "TIMED",
+        "config": { "sets": 1, "duration": 20 }
+      },
+      {
+        "drillId": "med_long_timed_drill",
+        "name": "Test: Timed Drill",
+        "description": "A timed drill.",
+        "type": "TIMED",
+        "config": { "sets": 1, "duration": 65 }
+      },
+      {
+        "drillId": "long_timed_drill",
+        "name": "Test: Timed Drill",
+        "description": "A 25-minute timed drill.",
+        "type": "TIMED",
+        "config": { "sets": 1, "duration": 1500 }
+      },
+      {
         "drillId": "short_rep_drill",
         "name": "Test: Rep-Based Drill",
         "description": "Log 1 set of 2 reps.",

--- a/lib/screens/active/widgets/make_target_timed_drill_widget.dart
+++ b/lib/screens/active/widgets/make_target_timed_drill_widget.dart
@@ -80,7 +80,7 @@ class _MakeTargetTimedDrillWidgetState extends State<MakeTargetTimedDrillWidget>
         Text(
           formatDuration(_elapsedSeconds),
           style: TextStyle(
-            fontSize: 60,
+            fontSize: 150,
             fontWeight: FontWeight.w900,
             color: _isComplete ? Colors.greenAccent : Colors.white,
           ),

--- a/lib/screens/active/widgets/make_target_timed_drill_widget.dart
+++ b/lib/screens/active/widgets/make_target_timed_drill_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../models/drill.dart';
 import '../../../services/workout_state.dart';
+import 'package:flutter_bball_app/utils/format_duration.dart';
 
 class MakeTargetTimedDrillWidget extends StatefulWidget {
   final Drill drill;
@@ -51,13 +52,6 @@ class _MakeTargetTimedDrillWidgetState extends State<MakeTargetTimedDrillWidget>
     });
   }
 
-  String _formatDuration(int totalSeconds) {
-    final duration = Duration(seconds: totalSeconds);
-    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
-    final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
-    return '$minutes:$seconds';
-  }
-
   @override
   void dispose() {
     _timer.cancel();
@@ -84,7 +78,7 @@ class _MakeTargetTimedDrillWidgetState extends State<MakeTargetTimedDrillWidget>
         ),
         const SizedBox(height: 20),
         Text(
-          _formatDuration(_elapsedSeconds),
+          formatDuration(_elapsedSeconds),
           style: TextStyle(
             fontSize: 60,
             fontWeight: FontWeight.w900,

--- a/lib/screens/active/widgets/timed_drill_widget.dart
+++ b/lib/screens/active/widgets/timed_drill_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../models/drill.dart';
 import '../../../services/workout_state.dart';
+import 'package:flutter_bball_app/utils/format_duration.dart';
 
 class TimedDrillWidget extends StatefulWidget {
   final Drill drill;
@@ -49,13 +50,6 @@ class _TimedDrillWidgetState extends State<TimedDrillWidget> {
     super.dispose();
   }
 
-  String _formatDuration(int totalSeconds) {
-    final duration = Duration(seconds: totalSeconds);
-    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
-    final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
-    return '$minutes:$seconds';
-  }
-
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -73,23 +67,17 @@ class _TimedDrillWidgetState extends State<TimedDrillWidget> {
           textAlign: TextAlign.center,
         ),
         const SizedBox(height: 30),
-        Container(
-          width: 240,
-          height: 240,
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            border: Border.all(
-              color: const Color(0xFF1f2937), // Medium Gray
-              width: 15,
-            ),
-          ),
+        Expanded(
           child: Center(
-            child: Text(
-              _formatDuration(_remainingSeconds),
-              style: const TextStyle(
-                fontSize: 60,
-                fontWeight: FontWeight.w900,
-                color: Colors.white,
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                formatDuration(_remainingSeconds),
+                style: const TextStyle(
+                  fontSize: 300,
+                  fontWeight: FontWeight.w900,
+                  color: Colors.white,
+                ),
               ),
             ),
           ),

--- a/lib/screens/summary/workout_summary_screen.dart
+++ b/lib/screens/summary/workout_summary_screen.dart
@@ -154,7 +154,7 @@ class WorkoutSummaryScreen extends StatelessWidget {
     } else if (drill.type == 'REP_BASED') {
       return '${result.makes} / ${drill.config['targetMakes']}';
     } else if (drill.type == 'MAKE_TARGET_TIMED') {
-      return '${result.makes} makes in ${formatDuration(result.elapsedSeconds)}';
+      return '${result.makes} makes in ${formatDurationVerbose(result.elapsedSeconds)}';
     }
     return '';
   }

--- a/lib/screens/summary/workout_summary_screen.dart
+++ b/lib/screens/summary/workout_summary_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import '../../models/workout_session.dart';
+import 'package:flutter_bball_app/utils/format_duration.dart';
 
 class WorkoutSummaryScreen extends StatelessWidget {
   final WorkoutSession session;
@@ -153,15 +154,8 @@ class WorkoutSummaryScreen extends StatelessWidget {
     } else if (drill.type == 'REP_BASED') {
       return '${result.makes} / ${drill.config['targetMakes']}';
     } else if (drill.type == 'MAKE_TARGET_TIMED') {
-      return '${result.makes} makes in ${_formatDuration(result.elapsedSeconds)}';
+      return '${result.makes} makes in ${formatDuration(result.elapsedSeconds)}';
     }
     return '';
-  }
-
-  String _formatDuration(int totalSeconds) {
-    final duration = Duration(seconds: totalSeconds);
-    final minutes = duration.inMinutes;
-    final seconds = duration.inSeconds.remainder(60);
-    return '${minutes}m ${seconds}s';
   }
 }

--- a/lib/utils/format_duration.dart
+++ b/lib/utils/format_duration.dart
@@ -1,0 +1,12 @@
+// Utility function to format a duration in seconds for timer display.
+String formatDuration(int totalSeconds) {
+  if (totalSeconds >= 60) {
+    final minutes = (totalSeconds ~/ 60).toString();
+    final seconds = (totalSeconds % 60).toString().padLeft(2, '0');
+    return '$minutes:$seconds';
+  } else if (totalSeconds >= 10) {
+    return totalSeconds.toString();
+  } else {
+    return totalSeconds.toString();
+  }
+} 

--- a/lib/utils/format_duration.dart
+++ b/lib/utils/format_duration.dart
@@ -9,4 +9,11 @@ String formatDuration(int totalSeconds) {
   } else {
     return totalSeconds.toString();
   }
+}
+
+// Utility function to format a duration in seconds for summary display as 'Xm Ys'.
+String formatDurationVerbose(int totalSeconds) {
+  final minutes = totalSeconds ~/ 60;
+  final seconds = totalSeconds % 60;
+  return '${minutes}m ${seconds}s';
 } 

--- a/test/utils/format_duration_test.dart
+++ b/test/utils/format_duration_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bball_app/utils/format_duration.dart';
+
+void main() {
+  group('formatDuration', () {
+    test('formats minutes and seconds for 60 seconds or more', () {
+      expect(formatDuration(300), '5:00'); // 5 minutes
+      expect(formatDuration(69), '1:09'); // 1 minute, 9 seconds
+      expect(formatDuration(60), '1:00'); // exactly 1 minute
+    });
+
+    test('formats seconds only for 10-59 seconds', () {
+      expect(formatDuration(59), '59');
+      expect(formatDuration(10), '10');
+      expect(formatDuration(11), '11');
+    });
+
+    test('formats single digit for 0-9 seconds', () {
+      expect(formatDuration(9), '9');
+      expect(formatDuration(1), '1');
+      expect(formatDuration(0), '0');
+    });
+  });
+} 


### PR DESCRIPTION
For workouts that display a timer, the timer should appear as big as possible. Some workouts have a circular progress meter → we should remove this to allow the timer to display larger

![image](https://github.com/user-attachments/assets/dcd47faa-aec7-4b84-885d-f4efa67b5538)


![image](https://github.com/user-attachments/assets/4232d00e-5125-434c-925b-5a62780789b5)
