### PR TITLE
Reset drill controls

### DIFF
--- a/lib/screens/active/widgets/make_target_timed_drill_widget.dart
+++ b/lib/screens/active/widgets/make_target_timed_drill_widget.dart
@@ -19,11 +19,38 @@ class _MakeTargetTimedDrillWidgetState extends State<MakeTargetTimedDrillWidget>
   int _elapsedSeconds = 0;
   int _currentMakes = 0;
   bool _isComplete = false;
+  int? _lastDrillIndex;
+  int? _lastResetCounter;
 
   @override
   void initState() {
     super.initState();
     _startTimer();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final workoutState = Provider.of<WorkoutState>(context);
+    final currentDrillIndex = workoutState.currentDrillIndex;
+    final resetCounter = workoutState.resetDrillCounter;
+    if (_lastDrillIndex == null) {
+      _lastDrillIndex = currentDrillIndex;
+      _lastResetCounter = resetCounter;
+    } else if (_lastDrillIndex == currentDrillIndex && _lastResetCounter != resetCounter) {
+      // Only reset if resetDrillCounter changed
+      _timer.cancel();
+      setState(() {
+        _elapsedSeconds = 0;
+        _currentMakes = 0;
+        _isComplete = false;
+      });
+      _startTimer();
+      _lastResetCounter = resetCounter;
+    } else {
+      _lastDrillIndex = currentDrillIndex;
+      _lastResetCounter = resetCounter;
+    }
   }
 
   void _startTimer() {

--- a/lib/screens/active/widgets/timed_drill_widget.dart
+++ b/lib/screens/active/widgets/timed_drill_widget.dart
@@ -17,12 +17,37 @@ class TimedDrillWidget extends StatefulWidget {
 class _TimedDrillWidgetState extends State<TimedDrillWidget> {
   late Timer _timer;
   late int _remainingSeconds;
+  int? _lastDrillIndex;
+  int? _lastResetCounter;
 
   @override
   void initState() {
     super.initState();
     _remainingSeconds = widget.drill.config['duration']!;
     _startTimer();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final workoutState = Provider.of<WorkoutState>(context);
+    final currentDrillIndex = workoutState.currentDrillIndex;
+    final resetCounter = workoutState.resetDrillCounter;
+    if (_lastDrillIndex == null) {
+      _lastDrillIndex = currentDrillIndex;
+      _lastResetCounter = resetCounter;
+    } else if (_lastDrillIndex == currentDrillIndex && _lastResetCounter != resetCounter) {
+      // Only reset if resetDrillCounter changed
+      _timer.cancel();
+      setState(() {
+        _remainingSeconds = widget.drill.config['duration']!;
+      });
+      _startTimer();
+      _lastResetCounter = resetCounter;
+    } else {
+      _lastDrillIndex = currentDrillIndex;
+      _lastResetCounter = resetCounter;
+    }
   }
 
   void _startTimer() {

--- a/lib/services/workout_state.dart
+++ b/lib/services/workout_state.dart
@@ -10,6 +10,7 @@ class WorkoutState extends ChangeNotifier {
   int _currentDrillIndex = 0;
   bool _isPaused = false;
   final List<DrillResult> _sessionResults = [];
+  int _resetDrillCounter = 0;
 
   // Public getters to safely access the state
   bool get isWorkoutStarted => _blueprint != null;
@@ -26,6 +27,7 @@ class WorkoutState extends ChangeNotifier {
   int get totalDrills => _blueprint?.drills.length ?? 0;
   List<DrillResult> get results => _sessionResults;
   int get currentDrillIndex => _currentDrillIndex;
+  int get resetDrillCounter => _resetDrillCounter;
 
   double get workoutProgress {
     if (!isWorkoutStarted || totalDrills == 0) {
@@ -129,5 +131,20 @@ class WorkoutState extends ChangeNotifier {
   // Method to discard workout without saving
   void discardWorkout() {
     endWorkout();
+  }
+
+  // Go to the previous drill (if not at the first drill)
+  void previousDrill() {
+    if (_currentDrillIndex > 0) {
+      _currentDrillIndex--;
+      notifyListeners();
+    }
+  }
+
+  // Reset the current drill (widgets should listen and reset their local state)
+  void resetCurrentDrill() {
+    _resetDrillCounter++;
+    // This method notifies listeners so drill widgets can reset their local state (timer, makes, etc.)
+    notifyListeners();
   }
 }


### PR DESCRIPTION
Adds [Prev] [Pause/Resume] [END] [Next] controls to the active workout screen.
Implements long-press on "Prev" to reset the current drill (timer, makes, etc.).
Ensures reset logic is isolated from pause/resume and other state changes.
Uses a resetDrillCounter in WorkoutState to distinguish explicit resets.
Updates both Timed and Make Target Timed drill widgets to respond only to explicit resets.
