### PR TITLE
Fix race condition in settings loading

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -16,8 +16,12 @@ class SettingsService extends ChangeNotifier {
   bool get announceDrillDescription => _announceDrillDescription;
   bool get announceDrillTargetMakes => _announceDrillTargetMakes;
 
-  SettingsService() {
-    _loadSettings();
+  SettingsService._();
+
+  static Future<SettingsService> create() async {
+    final service = SettingsService._();
+    await service._loadSettings();
+    return service;
   }
 
   Future<void> _loadSettings() async {


### PR DESCRIPTION
Introduce a static factory method for `SettingsService` to ensure settings are loaded before the service is used, fixing a race condition.