### PR TITLE
Fix race condition in settings loading

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,15 +5,37 @@ import 'package:flutter_bball_app/services/workout_state.dart';
 import 'package:provider/provider.dart';
 
 void main() {
-  runApp(
-    MultiProvider(
-      providers: [
-        ChangeNotifierProvider(create: (context) => WorkoutState()),
-        ChangeNotifierProvider(create: (context) => SettingsService()),
-      ],
-      child: const BballTrainerApp(),
-    ),
-  );
+  runApp(const AppInitializer());
+}
+
+class AppInitializer extends StatelessWidget {
+  const AppInitializer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<SettingsService>(
+      future: SettingsService.create(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.done && snapshot.hasData) {
+          return MultiProvider(
+            providers: [
+              ChangeNotifierProvider(create: (context) => WorkoutState()),
+              ChangeNotifierProvider.value(value: snapshot.data!),
+            ],
+            child: const BballTrainerApp(),
+          );
+        } else {
+          return const MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: CircularProgressIndicator(),
+              ),
+            ),
+          );
+        }
+      },
+    );
+  }
 }
 
 class BballTrainerApp extends StatelessWidget {

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -16,8 +16,12 @@ class SettingsService extends ChangeNotifier {
   bool get announceDrillDescription => _announceDrillDescription;
   bool get announceDrillTargetMakes => _announceDrillTargetMakes;
 
-  SettingsService() {
-    _loadSettings();
+  SettingsService._();
+
+  static Future<SettingsService> create() async {
+    final service = SettingsService._();
+    await service._loadSettings();
+    return service;
   }
 
   Future<void> _loadSettings() async {

--- a/test/services/settings_service_test.dart
+++ b/test/services/settings_service_test.dart
@@ -3,8 +3,8 @@ import 'package:flutter_bball_app/services/settings_service.dart';
 
 void main() {
   group('SettingsService', () {
-    test('should have default values as true', () {
-      final settings = SettingsService();
+    test('should have default values as true', () async {
+      final settings = await SettingsService.create();
       
       expect(settings.announceDrillName, true);
       expect(settings.announceDrillDescription, true);
@@ -12,7 +12,7 @@ void main() {
     });
 
     test('should update announceDrillName', () async {
-      final settings = SettingsService();
+      final settings = await SettingsService.create();
       
       await settings.setAnnounceDrillName(false);
       expect(settings.announceDrillName, false);
@@ -22,7 +22,7 @@ void main() {
     });
 
     test('should update announceDrillDescription', () async {
-      final settings = SettingsService();
+      final settings = await SettingsService.create();
       
       await settings.setAnnounceDrillDescription(false);
       expect(settings.announceDrillDescription, false);
@@ -32,7 +32,7 @@ void main() {
     });
 
     test('should update announceDrillTargetMakes', () async {
-      final settings = SettingsService();
+      final settings = await SettingsService.create();
       
       await settings.setAnnounceDrillTargetMakes(false);
       expect(settings.announceDrillTargetMakes, false);
@@ -42,7 +42,7 @@ void main() {
     });
 
     test('should notify listeners when settings change', () async {
-      final settings = SettingsService();
+      final settings = await SettingsService.create();
       int notificationCount = 0;
       
       settings.addListener(() {


### PR DESCRIPTION
Fix `SettingsService` race condition by awaiting settings load during initialization.