### PR TITLE
[TOURNEY] Add separate tourney app screen - make them seem like different apps

### DIFF
--- a/lib/danzig_cup_app/danzig_cup_app.dart
+++ b/lib/danzig_cup_app/danzig_cup_app.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class DanzigCupApp extends StatelessWidget {
+  const DanzigCupApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Danzig Cup 2v2 Tournament',
+      debugShowCheckedModeBanner: false,
+      theme: _scoreboardTheme,
+      home: const DanzigCupHome(),
+    );
+  }
+}
+
+class DanzigCupHome extends StatefulWidget {
+  const DanzigCupHome({super.key});
+
+  @override
+  State<DanzigCupHome> createState() => _DanzigCupHomeState();
+}
+
+class _DanzigCupHomeState extends State<DanzigCupHome> {
+  String _selectedScreen = 'Player Register';
+
+  Widget _buildBody() {
+    switch (_selectedScreen) {
+      case 'Player Register':
+        return Center(
+          child: Text(
+            'Player Register',
+            style: Theme.of(context).textTheme.headlineMedium,
+          ),
+        );
+      case 'Tournament Manager':
+        return Center(
+          child: Text(
+            'Tournament Manager',
+            style: Theme.of(context).textTheme.headlineMedium,
+          ),
+        );
+      default:
+        return const Center(child: Text('Select a screen'));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Danzig Cup 2v2 Tournament'),
+      ),
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            DrawerHeader(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.secondary,
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.sports_basketball,
+                    size: 64,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'DANZIG CUP',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                ],
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.person_add),
+              title: const Text('Player Register'),
+              onTap: () {
+                setState(() {
+                  _selectedScreen = 'Player Register';
+                });
+                Navigator.pop(context); // Close drawer
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.sports_basketball),
+              title: const Text('Tournament Manager'),
+              onTap: () {
+                setState(() {
+                  _selectedScreen = 'Tournament Manager';
+                });
+                Navigator.pop(context); // Close drawer
+              },
+            ),
+            const Divider(color: Color(0xFF39FF14)),
+            ListTile(
+              leading: const Icon(Icons.fitness_center),
+              title: const Text('Back to Workout App'),
+              onTap: () {
+                Navigator.pop(context); // Close drawer
+                Navigator.pop(context); // Go back to workout app
+              },
+            ),
+          ],
+        ),
+      ),
+      body: _buildBody(),
+    );
+  }
+}
+
+// Scoreboard theme
+final ThemeData _scoreboardTheme = ThemeData(
+  scaffoldBackgroundColor: const Color(0xFF111111),
+  colorScheme: const ColorScheme.dark(
+    primary: Color(0xFF39FF14), // Neon green
+    secondary: Color(0xFF181818), // Very dark gray
+    surface: Color(0xFF111111),
+    onPrimary: Colors.black,
+    onSecondary: Colors.white,
+  ),
+  appBarTheme: AppBarTheme(
+    backgroundColor: const Color(0xFF181818),
+    foregroundColor: const Color(0xFF39FF14),
+    titleTextStyle: GoogleFonts.orbitron(
+      color: const Color(0xFF39FF14),
+      fontSize: 24,
+      fontWeight: FontWeight.bold,
+    ),
+  ),
+  textTheme: GoogleFonts.orbitronTextTheme().apply(
+    bodyColor: Colors.white,
+    displayColor: const Color(0xFF39FF14),
+  ),
+  drawerTheme: const DrawerThemeData(
+    backgroundColor: Color(0xFF181818),
+  ),
+  iconTheme: const IconThemeData(color: Color(0xFF39FF14)),
+  elevatedButtonTheme: ElevatedButtonThemeData(
+    style: ElevatedButton.styleFrom(
+      backgroundColor: const Color(0xFF39FF14),
+      foregroundColor: Colors.black,
+      textStyle: GoogleFonts.orbitron(fontWeight: FontWeight.bold),
+    ),
+  ),
+  listTileTheme: const ListTileThemeData(
+    iconColor: Color(0xFF39FF14),
+    textColor: Colors.white,
+  ),
+);

--- a/lib/screens/library/workout_library_screen.dart
+++ b/lib/screens/library/workout_library_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bball_app/models/workout_blueprint.dart';
 import 'package:flutter_bball_app/repositories/workout_repository.dart';
 import 'package:flutter_bball_app/screens/detail/workout_detail_screen.dart';
 import 'package:flutter_bball_app/screens/history/workout_history_screen.dart';
+import 'package:flutter_bball_app/danzig_cup_app/danzig_cup_app.dart';
 
 class WorkoutLibraryScreen extends StatefulWidget {
   const WorkoutLibraryScreen({super.key});
@@ -62,6 +63,24 @@ class _WorkoutLibraryScreenState extends State<WorkoutLibraryScreen> {
                 'Choose a workout to start your session.',
                 style: textTheme.titleMedium?.copyWith(
                   color: const Color(0xFF9ca3af),
+                ),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton.icon(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const DanzigCupApp(),
+                    ),
+                  );
+                },
+                icon: const Icon(Icons.sports_basketball),
+                label: const Text('Go to Danzig Cup 2v2 Tournament App'),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF3b82f6),
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                 ),
               ),
               const SizedBox(height: 24),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -384,6 +384,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   firebase_core: ^2.30.0
   cloud_firestore: ^4.17.2
   audioplayers: ^5.2.1
+  google_fonts: ^6.2.1 
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
<img width="592" height="313" alt="image" src="https://github.com/user-attachments/assets/81da9e64-99c2-4af8-be64-dc7b3ee31519" />

<img width="1755" height="863" alt="image" src="https://github.com/user-attachments/assets/9855746e-387f-437d-8a88-84f6149e85da" />


Back to workout app doesn't really work yet